### PR TITLE
Add support for OpenAPI credentials-based authentication and refactor some code

### DIFF
--- a/applications/co/apps.go
+++ b/applications/co/apps.go
@@ -92,16 +92,8 @@ func GetCOAppsListingTool(s *server.MCPServer) {
 		),
 	)
 	s.AddTool(getCOAppsListingTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		mp := request.Params.Arguments["params"].(map[string]interface{})
-
 		params_list := []string{"page", "page_size", "configured", "q"}
-		params := map[string]string{}
-
-		for _, v := range params_list {
-			if _, ok := mp[v]; ok {
-				params[v] = mp[v].(string)
-			}
-		}
+		params := common.ExtractParams(request, params_list)
 		resp, err := GetCOAppsListing(params)
 		return common.MCPToolResponse(resp, []int{200}, err)
 	})
@@ -155,16 +147,8 @@ func COAppActionsListingTool(s *server.MCPServer) {
 		),
 	)
 	s.AddTool(getCOAppActionsListing, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		mp := request.Params.Arguments["params"].(map[string]interface{})
-
 		params_list := []string{"page", "page_size", "app_unique_id", "q"}
-		params := map[string]string{}
-		for _, v := range params_list {
-			if _, ok := mp[v]; ok {
-				params[v] = mp[v].(string)
-			}
-		}
-
+		params := common.ExtractParams(request, params_list)
 		resp, err := GetCOAppActionsListing(params)
 		return common.MCPToolResponse(resp, []int{200}, err)
 	})

--- a/applications/co/auth.go
+++ b/applications/co/auth.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/cyware-labs/cyware-mcpserver/common"
+	"resty.dev/v3"
 )
 
 const Login_endpoint = "/cpapi/rest-auth/login/"
@@ -26,7 +27,11 @@ func GenerateAuthHeaders() string {
 		Email:    CO_CONFIG.Auth.Username,
 		Password: common.Base64Encode(CO_CONFIG.Auth.Password),
 	}
-	CO_CLIENT.MakeRequest("POST", Login_endpoint, nil, &login_resp, login_payload, nil)
+	client := common.APIClient{
+		BASE_URL: CO_CONFIG.BASE_URL,
+		Client:   resty.New(),
+	}
+	client.MakeRequest("POST", Login_endpoint, nil, &login_resp, login_payload, nil)
 
 	return common.FormatCywareToken(login_resp.Token)
 }
@@ -55,17 +60,6 @@ func SetUpWorkspace() {
 	resp := GetLoggedInUserDetails()
 	USER_WS = resp.PreferredWorkspace.Code
 }
-
-// func LoginTool(s *server.MCPServer) {
-// 	loginTool := mcp.NewTool("login-to-co",
-// 		mcp.WithDescription("This tool will login into CO and set the auth token."),
-// 	)
-// 	s.AddTool(loginTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-// 		resp, err := Login()
-// 		SetUpWorkspace()
-// 		return common.MCPToolResponse(resp, []int{200}, err)
-// 	})
-// }
 
 func GetSoarEndpoint(endpoint string) string {
 	return fmt.Sprintf("/soarapi/%v/%v", USER_WS, endpoint)

--- a/applications/co/playbooks.go
+++ b/applications/co/playbooks.go
@@ -71,16 +71,8 @@ func GetPlayBookListTool(s *server.MCPServer) {
 		),
 	)
 	s.AddTool(getPlayBookListTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		mp := request.Params.Arguments["params"].(map[string]interface{})
-
 		params_list := []string{"page", "page_size", "status", "q"}
-		params := map[string]string{}
-
-		for _, v := range params_list {
-			if _, ok := mp[v]; ok {
-				params[v] = mp[v].(string)
-			}
-		}
+		params := common.ExtractParams(request, params_list)
 		resp, err := GetPlayBookList(params)
 		return common.MCPToolResponse(resp, []int{200}, err)
 	})

--- a/applications/ctix/auth.go
+++ b/applications/ctix/auth.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/cyware-labs/cyware-mcpserver/common"
+	"resty.dev/v3"
 )
 
 const Login_endpoint = "rest-auth/login/user-pass/"
@@ -32,7 +33,11 @@ func GenerateAuthHeaders() string {
 		Email:    CTIX_CONFIG.Auth.Username,
 		Password: CTIX_CONFIG.Auth.Password,
 	}
-	CTIX_CLIENT.MakeRequest("POST", Login_endpoint, nil, &login_resp, login_payload, nil)
+	client := common.APIClient{
+		BASE_URL: CTIX_CONFIG.BASE_URL,
+		Client:   resty.New(),
+	}
+	client.MakeRequest("POST", Login_endpoint, nil, &login_resp, login_payload, nil)
 	return common.FormatCywareToken(login_resp.Token)
 }
 
@@ -56,14 +61,3 @@ func Login() {
 		log.Printf("unsupported auth_type: %s", CTIX_CONFIG.Auth.Type)
 	}
 }
-
-// func LoginTool(s *server.MCPServer) {
-// 	loginTool := mcp.NewTool("login-to-ctix",
-// 		mcp.WithDescription("This tool will login into CTIX and set the auth token."),
-// 	)
-
-// 	s.AddTool(loginTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-// 		resp, err := Login()
-// 		return common.MCPToolResponse(resp, []int{200}, err)
-// 	})
-// }

--- a/applications/ctix/enrichment.go
+++ b/applications/ctix/enrichment.go
@@ -171,24 +171,16 @@ func GetEnrichmenToolsListTool(s *server.MCPServer) {
 	)
 
 	s.AddTool(getEnrichmenToolsList, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		mp := request.Params.Arguments["params"].(map[string]interface{})
-
 		params_list := []string{"page", "page_size", "is_active", "q"}
-
-		params := map[string]string{}
+		params := common.ExtractParams(request, params_list)
 		params["category"] = "threat_intelligence_enrichment"
-		for _, v := range params_list {
-			if _, ok := mp[v]; ok {
-				params[v] = mp[v].(string)
-			}
-		}
 		resp, err := GetEnrichmenToolsList(params)
 		return common.MCPToolResponse(resp, []int{200}, err)
 	})
 }
 
 func GetEnrichmentToolsDetails(app_id string) (*common.APIResponse, error) {
-	enrichment_tool_details_resp := EnrichmentToolDetails{}
+	var enrichment_tool_details_resp any
 	endpoint := enrichment_tool_details + app_id + "/"
 	resp, err := CTIX_CLIENT.MakeRequest("GET", endpoint, nil, &enrichment_tool_details_resp, nil, nil)
 	return &common.APIResponse{
@@ -202,6 +194,7 @@ func GetEnrichmentToolsDetailsTool(s *server.MCPServer) {
 		mcp.WithDescription("This tool will give details about the enrichment tool. Details like title, logo, metadata etc.s"),
 		mcp.WithString(
 			"app_id",
+			mcp.Required(),
 			mcp.Description("This is the app_id of the enrichment tool which is required to hit the endpoint to get the details"),
 		),
 	)
@@ -245,18 +238,8 @@ func GetEnrichmentToolActionConfigsTool(s *server.MCPServer) {
 
 	s.AddTool(getEnrichmentToolActionConfigs, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		app_id := request.Params.Arguments["app_id"].(string)
-
-		mp, _ := request.Params.Arguments["params"].(map[string]interface{})
-
 		params_list := []string{"page", "page_size"}
-		params := map[string]string{}
-		if mp != nil {
-			for _, v := range params_list {
-				if _, ok := mp[v]; ok {
-					params[v] = mp[v].(string)
-				}
-			}
-		}
+		params := common.ExtractParams(request, params_list)
 		resp, err := GetEnrichmentToolActionConfigs(app_id, params)
 		return common.MCPToolResponse(resp, []int{200}, err)
 	})
@@ -299,17 +282,8 @@ func GetAllEnrichmentToolSupportedForThreatDataObjectTool(s *server.MCPServer) {
 	)
 
 	s.AddTool(getAllEnrichmentToolSupportedForThreatDataObject, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		mp := request.Params.Arguments["params"].(map[string]interface{})
-
 		params_list := []string{"action_name", "is_active", "full_list"}
-		params := map[string]string{}
-
-		params["full_list"] = "true"
-		for _, v := range params_list {
-			if _, ok := mp[v]; ok {
-				params[v] = mp[v].(string)
-			}
-		}
+		params := common.ExtractParams(request, params_list)
 		resp, err := GetAllEnrichmentToolSupportedForThreatDataObject(params)
 		return common.MCPToolResponse(resp, []int{200}, err)
 	})
@@ -361,15 +335,8 @@ func EnrichThreatDataObjectTool(s *server.MCPServer) {
 	)
 
 	s.AddTool(enrichThreatDataObjectTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		mp := request.Params.Arguments["params"].(map[string]interface{})
 		params_list := []string{"app_slug", "value", "action_slug", "object_id", "object_type", "ioc_type"}
-		params := map[string]string{}
-
-		for _, v := range params_list {
-			if _, ok := mp[v]; ok {
-				params[v] = mp[v].(string)
-			}
-		}
+		params := common.ExtractParams(request, params_list)
 		resp, err := EnrichThreatDataObject(params)
 		return common.MCPToolResponse(resp, []int{200}, err)
 	})

--- a/applications/ctix/helpers/cql_grammar.go
+++ b/applications/ctix/helpers/cql_grammar.go
@@ -262,12 +262,28 @@ The value must be in string and which is epoch equivalent of the date.
 Supported operators: =, !=, >, >=, <, <=, RANGE
 
 Examples:
+ctix_created > "1746901800"
 ctix_created >= "1746901800"
 ctix_created = "1746901800"
 ctix_created != "1746901800"
 ctix_created <= "1746901800"
 ctix_created < "1746901800"
 ctix_created RANGE ("1746297000","1746988199")
+
+20. confidence_score
+Represet the confidence score(also knowns as risk score) of the threat data object.
+Example: If you want to get the data having risk score greater than 75, use confidence_score > "75"
+The value must be in string and must be between 0 to 100 inclusive.
+Supported operators: =, !=, >, >=, <, <=, RANGE
+
+Examples:
+confidence_score > "75"
+confidence_score >= "75"
+confidence_score = "75"
+confidence_score != "75"
+confidence_score <= "75"
+confidence_score < "75"
+confidence_score RANGE ("75","90")
 ---
 
 📌 Additional Notes for Query Construction:

--- a/applications/ctix/initializer.go
+++ b/applications/ctix/initializer.go
@@ -1,10 +1,17 @@
 package ctix
 
 import (
+	"log"
+	"time"
+
 	"github.com/cyware-labs/cyware-mcpserver/common"
 	"github.com/mark3labs/mcp-go/server"
 	"resty.dev/v3"
 )
+
+const retry = 4
+
+var failed_status = []int{400, 401}
 
 // CTIX_CLIENT is the shared HTTP client for all CTIX-related API requests.
 var CTIX_CLIENT common.APIClient
@@ -24,10 +31,42 @@ func InitClient(cfg *common.Config) {
 	CTIX_CONFIG = cfg.Applications["ctix"]
 	CTIX_CONFIG.BASE_URL = common.GetDomain(CTIX_CONFIG.BASE_URL) + "/ctixapi/"
 
+	c := resty.New()
+	c.SetAllowNonIdempotentRetry(true)
+	c.SetRetryCount(retry)
+	c.SetRetryWaitTime(1 * time.Second)
+
+	// Retry condition
+	c.AddRetryConditions(func(r *resty.Response, err error) bool {
+		return r != nil && common.ContainsStatusCode(failed_status, r.StatusCode())
+	})
+
+	c.AddRetryHooks(func(r *resty.Response, err error) {
+		if r != nil && common.ContainsStatusCode(failed_status, r.StatusCode()) {
+			log.Printf("Got failed status, attempting login before retry\n")
+
+			switch CTIX_CONFIG.Auth.Type {
+			case "basic":
+
+				auth_token := GenerateAuthHeaders()
+
+				// Updating the client as well as its basic
+				CTIX_CLIENT.Client.SetHeader("Authorization", auth_token)
+
+				// Updating the REQUEST object that will be retried
+				r.Request.SetHeader("Authorization", auth_token)
+			case "openapicreds":
+				newParams := common.GenerateAuthParams(CTIX_CONFIG.Auth.AccessID, CTIX_CONFIG.Auth.SecretKey)
+				// Updating the REQUEST object that will be retried
+				r.Request.SetQueryParams(newParams)
+			}
+		}
+	})
+
 	// initializing global httpclient which will be used for all the CTIX related APIs
 	CTIX_CLIENT = common.APIClient{
 		BASE_URL: CTIX_CONFIG.BASE_URL,
-		Client:   resty.New(),
+		Client:   c,
 	}
 }
 
@@ -50,7 +89,7 @@ func InitTools(s *server.MCPServer) {
 	// login and setting the token for all the subsequent requests
 	Login()
 
-	LoginTool(s)
+	// LoginTool(s)
 	GetLoggedInUserDetailsTool(s)
 
 	// cql and search

--- a/applications/ctix/tags.go
+++ b/applications/ctix/tags.go
@@ -62,16 +62,8 @@ func GetCTIXTagListingTool(s *server.MCPServer) {
 		),
 	)
 	s.AddTool(getCTIXTagListing, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		mp := request.Params.Arguments["params"].(map[string]interface{})
-
 		params_list := []string{"page", "page_size", "tag_type", "q"}
-		params := map[string]string{}
-
-		for _, v := range params_list {
-			if _, ok := mp[v]; ok {
-				params[v] = mp[v].(string)
-			}
-		}
+		params := common.ExtractParams(request, params_list)
 		resp, err := GetCTIXTagListing(params)
 		return common.MCPToolResponse(resp, []int{200}, err)
 	})

--- a/applications/ctix/threat_data_details.go
+++ b/applications/ctix/threat_data_details.go
@@ -172,16 +172,8 @@ func GetThreatDataObjectRelationsTool(s *server.MCPServer) {
 		object_type := request.Params.Arguments["object_type"].(string)
 		object_id := request.Params.Arguments["object_id"].(string)
 
-		mp := request.Params.Arguments["params"].(map[string]any)
-
-		params_list := []string{"direction", "page", "page_size"}
-
-		params := map[string]string{}
-		for _, v := range params_list {
-			if _, ok := mp[v]; ok {
-				params[v] = mp[v].(string)
-			}
-		}
+		params_list := []string{"direction", "page", "page_size", "object_type", "q"}
+		params := common.ExtractParams(request, params_list)
 		resp, err := GetThreatDataObjectRelations(params, object_id, object_type)
 		return common.MCPToolResponse(resp, []int{200}, err)
 	})

--- a/applications/ctix/threat_data_list.go
+++ b/applications/ctix/threat_data_list.go
@@ -41,12 +41,12 @@ func CQLCTIXSearchGrammarTool(s *server.MCPServer) {
 	})
 }
 
-func GetCQLQuerySearchResult(query string, page string, page_size string) (*common.APIResponse, error) {
+func GetCQLQuerySearchResult(sort string, query string, page string, page_size string) (*common.APIResponse, error) {
 	query = strings.ReplaceAll(query, "\"", "\\\"")
 	payload := strings.NewReader(fmt.Sprintf(`{"query": "%s"}`, query))
 
 	params := map[string]string{
-		"sort":      "-ctix_modified",
+		"sort":      sort,
 		"page":      page,
 		"page_size": page_size,
 	}
@@ -76,14 +76,20 @@ func GetCQLQuerySearchResultTool(s *server.MCPServer) {
 			mcp.Required(),
 			mcp.Description("This is the page size number of result per page. Used to get the specified number of result per page. Please note here if you are making paginated call then keep the page_size same in all the pages otherwise you will get duplicate entries in two different pages."),
 		),
+		mcp.WithString("sort",
+			mcp.Required(),
+			mcp.Description(`This is 'sort' params used to get the result in either descending/ascending order based on the value. Supported values are: confidence_score, ctix_modified, ctix_created only. Pass the value prefixed with '-' for descending order or as it for ascending order.
+			If nothing is specified then pass "-ctix_modified"`),
+		),
 	)
 
 	s.AddTool(getCQLQuerySearchResultTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		query := request.Params.Arguments["query"].(string)
 		page := request.Params.Arguments["page"].(string)
 		page_size := request.Params.Arguments["page_size"].(string)
+		sort := request.Params.Arguments["sort"].(string)
 
-		resp, err := GetCQLQuerySearchResult(query, page, page_size)
+		resp, err := GetCQLQuerySearchResult(sort, query, page, page_size)
 
 		return common.MCPToolResponse(resp, []int{200}, err)
 	})

--- a/applications/ctix/user_listing.go
+++ b/applications/ctix/user_listing.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/cyware-labs/cyware-mcpserver/common"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -110,16 +111,8 @@ func GetCTIXUserListingTool(s *server.MCPServer) {
 		),
 	)
 	s.AddTool(getCTIXUserListingTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		mp := request.Params.Arguments["params"].(map[string]interface{})
-
 		params_list := []string{"page", "page_size", "q", "is_active", "is_blocked", "is_read_only"}
-		params := map[string]string{}
-
-		for _, v := range params_list {
-			if _, ok := mp[v]; ok {
-				params[v] = mp[v].(string)
-			}
-		}
+		params := common.ExtractParams(request, params_list)
 		resp := GetCTIXUserListing(params)
 		result, _ := json.Marshal(resp)
 
@@ -148,16 +141,8 @@ func GetCTIXUserGroupListTool(s *server.MCPServer) {
 		),
 	)
 	s.AddTool(getCTIXUserGroupListTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		mp := request.Params.Arguments["params"].(map[string]interface{})
-
 		params_list := []string{"page", "page_size", "q"}
-		params := map[string]string{}
-
-		for _, v := range params_list {
-			if _, ok := mp[v]; ok {
-				params[v] = mp[v].(string)
-			}
-		}
+		params := common.ExtractParams(request, params_list)
 		resp := GetCTIXUserGroupList(params)
 		result, _ := json.Marshal(resp)
 

--- a/applications/general/general.go
+++ b/applications/general/general.go
@@ -60,7 +60,8 @@ func DateStringToEpoch(dateStr string) (int64, error) {
 
 func ConvertDateStringToEpochTool(s *server.MCPServer) {
 	convertDateStringToEpochTool := mcp.NewTool("convert-date-string-to-epoch",
-		mcp.WithDescription(`This tool will convert the give date string of format "dd-mm-yyyy-hh-min-sec" to epoch.`),
+		mcp.WithDescription(`This tool will convert the give date string of format "dd-mm-yyyy-hh-min-sec" to epoch. 
+		!!Important!! You must always use this tool to convert datetime into epoch.`),
 		mcp.WithString("date",
 			mcp.Description(`Represents the date in the format "dd-mm-yyyy-hh-min-sec"`)),
 	)

--- a/cmd/config.yaml
+++ b/cmd/config.yaml
@@ -1,20 +1,28 @@
 applications:
   ctix:
-    base_url: "CTIX url"
+    base_url: "CTIX Base URL"
+    # Example URL : "https://demo.cyware.com/ctix/"
     auth:
-      type: "basic"
-      username: "username"
-      password: "password"
+      # type: "basic"
+      # username: "username"
+      # password: "password"
       # type: "token"
       # token: "token(The token can be obtained from the Authorization header of any API call of the product)"
+      type : "openapicreds"
+      access_id : "access_id"
+      secret_key : "secret_key"
   co:
-    base_url: "CO url"
+    base_url: "CO Base URL"
+    # Example URL : "https://demo.cyware.com/soar/"
     auth:
-      type: "basic"
-      username: "username"
-      password: "password"
+      # type: "basic"
+      # username: "username"
+      # password: "password"
       # type: "token"
       # token: "token(The token can be obtained from the Authorization header of any API call of the product)"
+      type : "openapicreds"
+      access_id : "access_id"
+      secret_key : "secret_key"
 server:
   mcp_mode: "stdio"
   # port: "5421"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -49,7 +49,7 @@ func main() {
 			log.Fatalf("Server error: %v\n", err)
 		}
 	case "sse":
-		sseServer := server.NewSSEServer(s, server.WithBaseURL("http://localhost"))
+		sseServer := server.NewSSEServer(s)
 		if err := sseServer.Start(":" + cfg.Server.Port); err != nil {
 			log.Fatalf("Server error: %v", err)
 		}

--- a/common/config.go
+++ b/common/config.go
@@ -17,17 +17,19 @@ type Server struct {
 // Auth defines the authentication configuration for an application.
 // It supports different auth types like "basic", "token".
 type Auth struct {
-	Type     string `yaml:"type"`
-	Username string `yaml:"username,omitempty"`
-	Password string `yaml:"password,omitempty"`
-	Token    string `yaml:"token,omitempty"`
+	Type      string `mapstructure:"type"`
+	Username  string `mapstructure:"username,omitempty"`
+	Password  string `mapstructure:"password,omitempty"`
+	Token     string `mapstructure:"token,omitempty"`
+	AccessID  string `mapstructure:"access_id,omitempty"`
+	SecretKey string `mapstructure:"secret_key,omitempty"`
 }
 
 // Application defines the configuration for an external application,
 // including its base URL and authentication credentials.
 type Application struct {
 	BASE_URL string `mapstructure:"base_url"`
-	Auth     Auth   `yaml:"auth"`
+	Auth     Auth   `mapstructure:"auth"`
 }
 
 // Config holds the top-level configuration structure loaded from a YAML file.

--- a/common/response.go
+++ b/common/response.go
@@ -19,13 +19,13 @@ func JsonifyResponse(obj any) any {
 }
 
 func MCPToolResponse(resp *APIResponse, expected_status_code []int, err error) (*mcp.CallToolResult, error) {
-	if err != nil || (resp.RawResponse != nil && !containsStatusCode(expected_status_code, resp.RawResponse.StatusCode())) {
+	if err != nil || (resp.RawResponse != nil && !ContainsStatusCode(expected_status_code, resp.RawResponse.StatusCode())) {
 		return mcp.NewToolResultText(fmt.Sprintf("An error occurred, Server responded with status code %v and response %v", resp.RawResponse.StatusCode(), resp.RawResponse.String())), err
 	}
 	return mcp.NewToolResultText(fmt.Sprintf("%v", resp.FilteredReponse)), nil
 }
 
-func containsStatusCode(codes []int, statusCode int) bool {
+func ContainsStatusCode(codes []int, statusCode int) bool {
 	for _, code := range codes {
 		if code == statusCode {
 			return true

--- a/common/utils.go
+++ b/common/utils.go
@@ -1,8 +1,14 @@
 package common
 
 import (
+	"crypto/hmac"
+	"crypto/sha1"
 	"encoding/base64"
+	"strconv"
 	"strings"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
 )
 
 func FormatCywareToken(rawToken string) string {
@@ -22,4 +28,47 @@ func FormatCywareToken(rawToken string) string {
 // Base64Encode encodes the input string to Base64 format
 func Base64Encode(input string) string {
 	return base64.StdEncoding.EncodeToString([]byte(input))
+}
+
+// GenerateAuthParams generates authentication parameters
+func GenerateAuthParams(accessID, secretKey string) map[string]string {
+	// Generating unix timestamp
+	unixTimestamp := time.Now().Unix()
+
+	// Adding 20 seconds for expires
+	expires := unixTimestamp + 20
+
+	// Creating the string to sign
+	toSign := accessID + "\n" + strconv.FormatInt(expires, 10)
+
+	// Generating HMAC-SHA1 hash
+	h := hmac.New(sha1.New, []byte(secretKey))
+	h.Write([]byte(toSign))
+	hash := h.Sum(nil)
+
+	// Converting to base64
+	hashInBase64 := base64.StdEncoding.EncodeToString(hash)
+
+	params := map[string]string{
+		"Expires":   strconv.FormatInt(expires, 10),
+		"AccessID":  accessID,
+		"Signature": hashInBase64,
+	}
+	return params
+}
+
+// ExtractParams extracts params key from the tool call request and convert them into a map
+func ExtractParams(request mcp.CallToolRequest, params_list []string) map[string]string {
+	params := map[string]string{}
+	mp, ok := request.Params.Arguments["params"].(map[string]interface{})
+	if !ok {
+		return params
+	}
+
+	for _, v := range params_list {
+		if _, ok := mp[v]; ok {
+			params[v] = mp[v].(string)
+		}
+	}
+	return params
 }


### PR DESCRIPTION
This PR contains:

Support for OpenAPI credentials-based authentication.

Separation of logic for extracting parameters from the tool request.

Addition of the risk_score field in CQL.