### PR TITLE
Fix two tool-handler panics: numeric params and nil RawResponse

### DIFF
--- a/common/response.go
+++ b/common/response.go
@@ -20,6 +20,12 @@ func JsonifyResponse(obj any) any {
 
 func MCPToolResponse(resp *APIResponse, expected_status_code []int, err error) (*mcp.CallToolResult, error) {
 	if err != nil || (resp.RawResponse != nil && !ContainsStatusCode(expected_status_code, resp.RawResponse.StatusCode())) {
+		// resp.RawResponse is nil when the request failed before any response
+		// was received (e.g. timeout / connection reset). Dereferencing it here
+		// would panic the tool handler, so report the transport error instead.
+		if resp.RawResponse == nil {
+			return mcp.NewToolResultText(fmt.Sprintf("An error occurred before a response was received: %v", err)), err
+		}
 		return mcp.NewToolResultText(fmt.Sprintf("An error occurred, Server responded with status code %v and response %v", resp.RawResponse.StatusCode(), resp.RawResponse.String())), err
 	}
 	return mcp.NewToolResultText(fmt.Sprintf("%v", resp.FilteredReponse)), nil

--- a/common/response_test.go
+++ b/common/response_test.go
@@ -1,0 +1,20 @@
+package common
+
+import (
+	"errors"
+	"testing"
+)
+
+// When a request fails before a response is received (e.g. timeout / connection
+// reset), resp.RawResponse is nil. MCPToolResponse previously dereferenced it in
+// the error branch and panicked the tool handler.
+func TestMCPToolResponseNilRawResponseDoesNotPanic(t *testing.T) {
+	resp := &APIResponse{RawResponse: nil}
+	result, err := MCPToolResponse(resp, []int{200}, errors.New("dial tcp: i/o timeout"))
+	if err == nil {
+		t.Fatal("expected the transport error to be propagated")
+	}
+	if result == nil {
+		t.Fatal("expected a tool result describing the error, got nil")
+	}
+}

--- a/common/utils.go
+++ b/common/utils.go
@@ -4,6 +4,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/base64"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -71,11 +72,30 @@ func ExtractParams(request mcp.CallToolRequest, params_list []string) map[string
 	}
 
 	for _, v := range params_list {
-		if _, ok := mp[v]; ok {
-			params[v] = mp[v].(string)
+		if val, ok := mp[v]; ok {
+			params[v] = anyToString(val)
 		}
 	}
 	return params
+}
+
+// anyToString coerces a JSON-decoded value to a string. JSON numbers decode to
+// float64, so callers that pass numeric params (e.g. {"page": 1}) must not be
+// assumed to be strings — an unchecked type assertion panics the tool handler.
+func anyToString(val any) string {
+	switch t := val.(type) {
+	case string:
+		return t
+	case float64:
+		// Render integral values without a trailing ".0" (page=1 -> "1").
+		return strconv.FormatFloat(t, 'f', -1, 64)
+	case bool:
+		return strconv.FormatBool(t)
+	case nil:
+		return ""
+	default:
+		return fmt.Sprintf("%v", t)
+	}
 }
 
 func GetRestyClient(retryHook func(r *resty.Response, err error)) *resty.Client {

--- a/common/utils_test.go
+++ b/common/utils_test.go
@@ -1,0 +1,42 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// JSON numbers decode into interface{} as float64, so numeric params such as
+// {"page": 1} previously panicked ExtractParams via an unchecked .(string).
+func TestExtractParamsCoercesNonStringValues(t *testing.T) {
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"params": map[string]interface{}{
+			"page":      float64(1),
+			"page_size": float64(50),
+			"direction": "all",
+			"active":    true,
+		},
+	}
+
+	got := ExtractParams(req, []string{"page", "page_size", "direction", "active"})
+	want := map[string]string{
+		"page":      "1",
+		"page_size": "50",
+		"direction": "all",
+		"active":    "true",
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("param %q = %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+func TestExtractParamsMissingParamsKey(t *testing.T) {
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{}
+	if got := ExtractParams(req, []string{"page"}); len(got) != 0 {
+		t.Errorf("expected empty map, got %v", got)
+	}
+}


### PR DESCRIPTION
## **User description**
## Summary
Fixes two panics in CTIX tool handlers that crash the call (recovered by the mcp-go framework, surfaced to clients as `MCP error -32603: panic recovered ...`). Both are reachable from normal tool input.

### 1. `ExtractParams` panics on numeric params (`float64`, not `string`)
`common/utils.go` asserted every `params` value directly to `string`:

```go
params[v] = mp[v].(string)
```

JSON numbers decode into `interface{}` as `float64`, so any numeric param panics with:

```
interface conversion: interface {} is float64, not string
```

**Repro** — calling `get-threat-data-object-relations` (or any tool using `ExtractParams`) with integer pagination:

```json
{"object_type":"threat-actor","object_id":"…","params":{"direction":"all","page":1,"page_size":50,"object_type":"indicator"}}
```

Clients that send `page`/`page_size` as JSON numbers (rather than strings) hit this every time. The fix coerces values to string (`string` / `float64` / `bool`) instead of asserting.

### 2. `MCPToolResponse` nil-pointer dereference when no response was received
`common/response.go` guards `resp.RawResponse != nil` in the `if` condition, but the error branch still calls `resp.RawResponse.StatusCode()` / `.String()` unconditionally:

```go
if err != nil || (resp.RawResponse != nil && !ContainsStatusCode(...)) {
    return mcp.NewToolResultText(fmt.Sprintf("... %v ... %v", resp.RawResponse.StatusCode(), resp.RawResponse.String())), err
}
```

When a request fails **before** a response is received (timeout, connection reset), `err != nil` and `resp.RawResponse == nil`, so this panics with:

```
runtime error: invalid memory address or nil pointer dereference
```

The fix reports the transport error when `RawResponse` is nil instead of dereferencing it. (Because the server sets no client request timeout, slow CTIX queries that the caller times out commonly reach this path.)

## Changes
- `common/utils.go`: `ExtractParams` now coerces param values to string via a small `anyToString` helper.
- `common/response.go`: `MCPToolResponse` nil-guards `resp.RawResponse` in the error branch.
- Added `common/utils_test.go` and `common/response_test.go` covering both cases.

## Testing
`go build ./...`, `go vet ./...`, and `go test ./common/...` all pass; `gofmt` clean.


___

## **CodeAnt-AI Description**
**Fix crashes in tool handlers when params are numeric or a request fails before a response arrives**

### What Changed
- Numeric and boolean tool parameters are now accepted without crashing, including values like `page: 1` and `active: true`
- If a request fails before any response is received, the tool now returns a clear transport error instead of crashing
- Added regression tests for both cases

### Impact
`✅ Fewer tool-handler crashes`
`✅ Clearer timeout and connection error messages`
`✅ Safer pagination and filter inputs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
