### PR TITLE
Support timeout for CQL query search

### DIFF
--- a/applications/ctix/threat_data_list.go
+++ b/applications/ctix/threat_data_list.go
@@ -2,10 +2,8 @@ package ctix
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/cyware-labs/cyware-mcpserver/applications/ctix/helpers"
 	"github.com/cyware-labs/cyware-mcpserver/common"
@@ -99,48 +97,13 @@ func GetCQLQuerySearchResultTool(s *server.MCPServer) {
 		sort := request.Params.Arguments["sort"].(string)
 
 		if timeoutArg, ok := request.Params.Arguments["timeout_seconds"]; ok {
-			var timeoutSeconds float64
-			switch v := timeoutArg.(type) {
-			case float64:
-				timeoutSeconds = v
-			case float32:
-				timeoutSeconds = float64(v)
-			case int:
-				timeoutSeconds = float64(v)
-			case int8:
-				timeoutSeconds = float64(v)
-			case int16:
-				timeoutSeconds = float64(v)
-			case int32:
-				timeoutSeconds = float64(v)
-			case int64:
-				timeoutSeconds = float64(v)
-			case uint:
-				timeoutSeconds = float64(v)
-			case uint8:
-				timeoutSeconds = float64(v)
-			case uint16:
-				timeoutSeconds = float64(v)
-			case uint32:
-				timeoutSeconds = float64(v)
-			case uint64:
-				timeoutSeconds = float64(v)
-			case json.Number:
-				parsedTimeoutSeconds, err := v.Float64()
-				if err != nil {
-					return nil, fmt.Errorf("timeout_seconds must be a number")
-				}
-				timeoutSeconds = parsedTimeoutSeconds
-			default:
-				return nil, fmt.Errorf("timeout_seconds must be a number")
-			}
-
-			if timeoutSeconds <= 0 {
-				return nil, fmt.Errorf("timeout_seconds must be greater than 0")
+			timeoutDuration, err := common.ParseTimeoutDuration(timeoutArg)
+			if err != nil {
+				return nil, err
 			}
 
 			var cancel context.CancelFunc
-			ctx, cancel = context.WithTimeout(ctx, time.Duration(timeoutSeconds*float64(time.Second)))
+			ctx, cancel = context.WithTimeout(ctx, timeoutDuration)
 			defer cancel()
 		}
 

--- a/applications/ctix/threat_data_list.go
+++ b/applications/ctix/threat_data_list.go
@@ -2,8 +2,10 @@ package ctix
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/cyware-labs/cyware-mcpserver/applications/ctix/helpers"
 	"github.com/cyware-labs/cyware-mcpserver/common"
@@ -42,6 +44,10 @@ func CQLCTIXSearchGrammarTool(s *server.MCPServer) {
 }
 
 func GetCQLQuerySearchResult(sort string, query string, page string, page_size string) (*common.APIResponse, error) {
+	return GetCQLQuerySearchResultWithContext(context.Background(), sort, query, page, page_size)
+}
+
+func GetCQLQuerySearchResultWithContext(ctx context.Context, sort string, query string, page string, page_size string) (*common.APIResponse, error) {
 	query = strings.ReplaceAll(query, "\"", "\\\"")
 	payload := strings.NewReader(fmt.Sprintf(`{"query": "%s"}`, query))
 
@@ -53,7 +59,7 @@ func GetCQLQuerySearchResult(sort string, query string, page string, page_size s
 
 	threat_data_list_resp := ThreatDataListResp{}
 
-	resp, err := CTIX_CLIENT.MakeRequest("POST", threat_data_list, params, &threat_data_list_resp, payload, nil)
+	resp, err := CTIX_CLIENT.MakeRequestWithContext(ctx, "POST", threat_data_list, params, &threat_data_list_resp, payload, nil)
 
 	return &common.APIResponse{
 		FilteredReponse: common.JsonifyResponse(threat_data_list_resp),
@@ -81,6 +87,9 @@ func GetCQLQuerySearchResultTool(s *server.MCPServer) {
 			mcp.Description(`This is 'sort' params used to get the result in either descending/ascending order based on the value. Supported values are: confidence_score, ctix_modified, ctix_created only. Pass the value prefixed with '-' for descending order or as it for ascending order.
 			If nothing is specified then pass "-ctix_modified"`),
 		),
+		mcp.WithNumber("timeout_seconds",
+			mcp.Description("Optional timeout in seconds for the CQL query search request"),
+		),
 	)
 
 	s.AddTool(getCQLQuerySearchResultTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -89,7 +98,53 @@ func GetCQLQuerySearchResultTool(s *server.MCPServer) {
 		page_size := request.Params.Arguments["page_size"].(string)
 		sort := request.Params.Arguments["sort"].(string)
 
-		resp, err := GetCQLQuerySearchResult(sort, query, page, page_size)
+		if timeoutArg, ok := request.Params.Arguments["timeout_seconds"]; ok {
+			var timeoutSeconds float64
+			switch v := timeoutArg.(type) {
+			case float64:
+				timeoutSeconds = v
+			case float32:
+				timeoutSeconds = float64(v)
+			case int:
+				timeoutSeconds = float64(v)
+			case int8:
+				timeoutSeconds = float64(v)
+			case int16:
+				timeoutSeconds = float64(v)
+			case int32:
+				timeoutSeconds = float64(v)
+			case int64:
+				timeoutSeconds = float64(v)
+			case uint:
+				timeoutSeconds = float64(v)
+			case uint8:
+				timeoutSeconds = float64(v)
+			case uint16:
+				timeoutSeconds = float64(v)
+			case uint32:
+				timeoutSeconds = float64(v)
+			case uint64:
+				timeoutSeconds = float64(v)
+			case json.Number:
+				parsedTimeoutSeconds, err := v.Float64()
+				if err != nil {
+					return nil, fmt.Errorf("timeout_seconds must be a number")
+				}
+				timeoutSeconds = parsedTimeoutSeconds
+			default:
+				return nil, fmt.Errorf("timeout_seconds must be a number")
+			}
+
+			if timeoutSeconds <= 0 {
+				return nil, fmt.Errorf("timeout_seconds must be greater than 0")
+			}
+
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, time.Duration(timeoutSeconds*float64(time.Second)))
+			defer cancel()
+		}
+
+		resp, err := GetCQLQuerySearchResultWithContext(ctx, sort, query, page, page_size)
 
 		return common.MCPToolResponse(resp, []int{200}, err)
 	})

--- a/common/client.go
+++ b/common/client.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"context"
 	"net/http"
 
 	"resty.dev/v3"
@@ -12,8 +13,12 @@ type APIClient struct {
 }
 
 func (a *APIClient) MakeRequest(method string, endpoint string, queryParams map[string]string, result any, payload any, headers map[string]string) (*resty.Response, error) {
+	return a.MakeRequestWithContext(context.Background(), method, endpoint, queryParams, result, payload, headers)
+}
+
+func (a *APIClient) MakeRequestWithContext(ctx context.Context, method string, endpoint string, queryParams map[string]string, result any, payload any, headers map[string]string) (*resty.Response, error) {
 	request_url := a.BASE_URL + endpoint
-	r := a.Client.R()
+	r := a.Client.R().SetContext(ctx)
 
 	var resp *resty.Response
 	var err error

--- a/common/client_test.go
+++ b/common/client_test.go
@@ -1,0 +1,52 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"resty.dev/v3"
+)
+
+func TestMakeRequestWithContextHonorsTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := &APIClient{
+		Client:   resty.New(),
+		BASE_URL: server.URL,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+
+	_, err := client.MakeRequestWithContext(ctx, http.MethodGet, "/", nil, nil, nil, nil)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context deadline exceeded, got %v", err)
+	}
+}
+
+func TestMCPToolResponseHandlesNilRawResponseError(t *testing.T) {
+	expectedErr := context.DeadlineExceeded
+
+	result, err := MCPToolResponse(&APIResponse{}, []int{http.StatusOK}, expectedErr)
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected deadline error, got %v", err)
+	}
+
+	content, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected text content, got %T", result.Content[0])
+	}
+	if !strings.Contains(content.Text, expectedErr.Error()) {
+		t.Fatalf("expected response text to include error, got %q", content.Text)
+	}
+}

--- a/common/response.go
+++ b/common/response.go
@@ -19,6 +19,9 @@ func JsonifyResponse(obj any) any {
 }
 
 func MCPToolResponse(resp *APIResponse, expected_status_code []int, err error) (*mcp.CallToolResult, error) {
+	if err != nil && (resp == nil || resp.RawResponse == nil) {
+		return mcp.NewToolResultText(fmt.Sprintf("An error occurred: %v", err)), err
+	}
 	if err != nil || (resp.RawResponse != nil && !ContainsStatusCode(expected_status_code, resp.RawResponse.StatusCode())) {
 		return mcp.NewToolResultText(fmt.Sprintf("An error occurred, Server responded with status code %v and response %v", resp.RawResponse.StatusCode(), resp.RawResponse.String())), err
 	}

--- a/common/utils.go
+++ b/common/utils.go
@@ -4,6 +4,9 @@ import (
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -76,6 +79,51 @@ func ExtractParams(request mcp.CallToolRequest, params_list []string) map[string
 		}
 	}
 	return params
+}
+
+func ParseTimeoutDuration(timeoutArg any) (time.Duration, error) {
+	var timeoutSeconds float64
+
+	switch v := timeoutArg.(type) {
+	case float64:
+		timeoutSeconds = v
+	case float32:
+		timeoutSeconds = float64(v)
+	case int:
+		timeoutSeconds = float64(v)
+	case int8:
+		timeoutSeconds = float64(v)
+	case int16:
+		timeoutSeconds = float64(v)
+	case int32:
+		timeoutSeconds = float64(v)
+	case int64:
+		timeoutSeconds = float64(v)
+	case uint:
+		timeoutSeconds = float64(v)
+	case uint8:
+		timeoutSeconds = float64(v)
+	case uint16:
+		timeoutSeconds = float64(v)
+	case uint32:
+		timeoutSeconds = float64(v)
+	case uint64:
+		timeoutSeconds = float64(v)
+	case json.Number:
+		parsedTimeoutSeconds, err := v.Float64()
+		if err != nil {
+			return 0, fmt.Errorf("timeout_seconds must be a number")
+		}
+		timeoutSeconds = parsedTimeoutSeconds
+	default:
+		return 0, fmt.Errorf("timeout_seconds must be a number")
+	}
+
+	if timeoutSeconds <= 0 || math.IsNaN(timeoutSeconds) || math.IsInf(timeoutSeconds, 0) {
+		return 0, fmt.Errorf("timeout_seconds must be greater than 0")
+	}
+
+	return time.Duration(timeoutSeconds * float64(time.Second)), nil
 }
 
 func GetRestyClient(retryHook func(r *resty.Response, err error)) *resty.Client {

--- a/common/utils_test.go
+++ b/common/utils_test.go
@@ -1,0 +1,57 @@
+package common
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+	"time"
+)
+
+func TestParseTimeoutDurationAcceptsNumericRepresentations(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  any
+		want time.Duration
+	}{
+		{name: "float64", arg: float64(1.5), want: 1500 * time.Millisecond},
+		{name: "float32", arg: float32(2), want: 2 * time.Second},
+		{name: "int", arg: int(3), want: 3 * time.Second},
+		{name: "int64", arg: int64(4), want: 4 * time.Second},
+		{name: "uint64", arg: uint64(5), want: 5 * time.Second},
+		{name: "json number", arg: json.Number("6.25"), want: 6250 * time.Millisecond},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseTimeoutDuration(tt.arg)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestParseTimeoutDurationRejectsInvalidValues(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  any
+	}{
+		{name: "string", arg: "1"},
+		{name: "bad json number", arg: json.Number("bad")},
+		{name: "zero", arg: 0},
+		{name: "negative", arg: -1},
+		{name: "nan", arg: math.NaN()},
+		{name: "infinity", arg: math.Inf(1)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := ParseTimeoutDuration(tt.arg); err == nil {
+				t.Fatalf("expected error")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## **User description**
## Summary
- add optional timeout_seconds argument to get-cql-query-search-result
- pass the MCP request context through the CQL search request path
- add a context-aware HTTP request helper while preserving the existing MakeRequest API

## Testing
- go test ./...


___

## **CodeAnt-AI Description**
**Add timeout support to CQL query searches**

### What Changed
- CQL search requests can now stop after a user-supplied timeout instead of waiting indefinitely
- The search tool accepts an optional `timeout_seconds` value and rejects non-number, zero, or negative values
- Canceled or timed-out requests now return a clear error message even when no server response is available
- Existing CQL search behavior still works when no timeout is provided

### Impact
`✅ Fewer hanging CQL searches`
`✅ Clearer timeout errors`
`✅ Shorter waits on slow query requests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
